### PR TITLE
Replace lambda resources with module

### DIFF
--- a/files/fetch_release.sh
+++ b/files/fetch_release.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+latest_tag=$(curl -s "https://api.github.com/repos/montblu/terraform-aws-logs-to-opensearch/releases/latest" | jq -r '.tag_name')
+echo "{\"tag\": \"$latest_tag\"}"

--- a/lambda.tf
+++ b/lambda.tf
@@ -1,5 +1,5 @@
 locals {
-  package_url = "https://github.com/montblu/terraform-aws-logs-to-opensearch/archive/refs/tags/${data.external.latest_release.result["tag"]}.zip"
+  package_url = var.desired_version != "" ? "https://github.com/montblu/terraform-aws-logs-to-opensearch/archive/refs/tags/${var.desired_version}.zip" : "https://github.com/montblu/terraform-aws-logs-to-opensearch/archive/refs/tags/${data.external.latest_release.result["tag"]}.zip"
   downloaded  = "downloaded_package_${md5(local.package_url)}.zip"
 }
 
@@ -17,7 +17,7 @@ resource "null_resource" "download_package" {
       set -e
       curl -L -o ${local.downloaded} ${local.package_url}
       unzip -o ${local.downloaded} -d ${path.module}/
-    EOT 
+    EOT
   }
 }
 data "null_data_source" "downloaded_package" {

--- a/lambda.tf
+++ b/lambda.tf
@@ -36,8 +36,9 @@ module "alb_logs_to_elasticsearch_vpc" {
   timeout                = 600  # Set this to 10 minutes to avoid timeouts in case of a large VPC flow logs
   lambda_role            = aws_iam_role.role.arn
   local_existing_package = data.null_data_source.downloaded_package.outputs["filename"]
-
-  create_package = false
+  create_role            = false
+  create_package         = false
+  publish                = true
 
   environment_variables = {
     INDEX_PREFIX                 = var.name_prefix
@@ -55,8 +56,9 @@ module "alb_logs_to_elasticsearch_vpc" {
   )
 
   allowed_triggers = {
-    statement_id = "AllowExecutionFromS3Bucket"
-    principal    = "s3.amazonaws.com"
-    source_arn   = var.s3_bucket_arn
+    S3 = {
+      principal  = "s3.amazonaws.com"
+      source_arn = var.s3_bucket_arn
+    }
   }
 }

--- a/lambda.tf
+++ b/lambda.tf
@@ -13,10 +13,13 @@ resource "null_resource" "download_package" {
   }
 
   provisioner "local-exec" {
-    command = "curl -L -o ${local.downloaded} ${local.package_url}"
+    command = <<EOT
+      set -e
+      curl -L -o ${local.downloaded} ${local.package_url}
+      unzip -o ${local.downloaded} -d ${path.module}/
+    EOT 
   }
 }
-
 data "null_data_source" "downloaded_package" {
   inputs = {
     id       = null_resource.download_package.id
@@ -35,7 +38,7 @@ module "alb_logs_to_elasticsearch_vpc" {
   memory_size            = 1024 # Set this to 1024MB to avoid timeouts in case of a large VPC flow logs
   timeout                = 600  # Set this to 10 minutes to avoid timeouts in case of a large VPC flow logs
   lambda_role            = aws_iam_role.role.arn
-  local_existing_package = data.null_data_source.downloaded_package.outputs["filename"]
+  local_existing_package = "${path.module}/alb-logs-to-elasticsearch.zip"
   create_role            = false
   create_package         = false
   publish                = true

--- a/s3.tf
+++ b/s3.tf
@@ -2,7 +2,7 @@ resource "aws_s3_bucket_notification" "alb_logs_to_elasticsearch_vpc" {
   bucket = var.s3_bucket_id
 
   lambda_function {
-    lambda_function_arn = aws_lambda_function.alb_logs_to_elasticsearch_vpc.arn
+    lambda_function_arn = module.alb_logs_to_elasticsearch_vpc.lambda_function_arn
     events              = ["s3:ObjectCreated:*"]
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -57,3 +57,9 @@ variable "send_only_vpc_logs_with_dest_port" {
   type    = string
   default = ""
 }
+
+variable "desired_version" {
+  type        = string
+  description = "Desired version to fetch. Will get latest if left empty"
+  default     = ""
+}


### PR DESCRIPTION
Applying with non-existent version:

```
│ Error: local-exec provisioner error
│ 
│   with module.lambda-test.null_resource.download_package,
│   on .terraform/modules/lambda-test/lambda.tf line 16, in resource "null_resource" "download_package":
│   16:   provisioner "local-exec" {
│ 
│ Error running command '      set -e
│       curl -L -o downloaded_package_416c8aa295ca3f5339b1b2ecbb81691c.zip https://github.com/montblu/terraform-aws-logs-to-opensearch/archive/refs/tags/v1.2.3.zip
│       unzip -o downloaded_package_416c8aa295ca3f5339b1b2ecbb81691c.zip -d .terraform/modules/lambda-test/
│ ': exit status 9. Output:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
│                                  Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
│ 0
100    14  100    14    0     0     16      0 --:--:-- --:--:-- --:--:--    16
│ Archive:  downloaded_package_416c8aa295ca3f5339b1b2ecbb81691c.zip
│   End-of-central-directory signature not found.  Either this file is not
│   a zipfile, or it constitutes one disk of a multi-part archive.  In the
│   latter case the central directory and zipfile comment will be found on
│   the last disk(s) of this archive.
│ unzip:  cannot find zipfile directory in one of downloaded_package_416c8aa295ca3f5339b1b2ecbb81691c.zip or
│         downloaded_package_416c8aa295ca3f5339b1b2ecbb81691c.zip.zip, and cannot find downloaded_package_416c8aa295ca3f5339b1b2ecbb81691c.zip.ZIP, period.
```

Applying with existing version or without the desired_version variable input:

```
module.lambda-test.null_resource.download_package: Provisioning with 'local-exec'...
module.lambda-test.null_resource.download_package (local-exec): Executing: ["/bin/sh" "-c" "      set -e\n      curl -L -o downloaded_package_65d64672524938bc7a14a0858494b3d0.zip https://github.com/montblu/terraform-aws-logs-to-opensearch/archive/refs/tags/v1.0.0.zip\n      unzip -o downloaded_package_65d64672524938bc7a14a0858494b3d0.zip -d .terraform/modules/lambda-test/\n"]
module.lambda-test.null_resource.download_package (local-exec):   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
module.lambda-test.null_resource.download_package (local-exec):                                  Dload  Upload   Total   Spent    Left  Speed
module.lambda-test.null_resource.download_package (local-exec):   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
module.lambda-test.null_resource.download_package (local-exec):   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
module.lambda-test.null_resource.download_package (local-exec): 100 12933    0 12933    0     0   9968      0 --:--:--  0:00:01 --:--:--  9968
module.lambda-test.null_resource.download_package (local-exec): 100  612k    0  612k    0     0   391k      0 --:--:--  0:00:01 --:--:-- 2223k
module.lambda-test.null_resource.download_package (local-exec): 100 3686k    0 3686k    0     0  1436k      0 --:--:--  0:00:02 --:--:-- 2892k
module.lambda-test.null_resource.download_package (local-exec): 100 5319k    0 5319k    0     0  1491k      0 --:--:--  0:00:03 --:--:-- 2338k
module.lambda-test.null_resource.download_package (local-exec): 100 6910k    0 6910k    0     0  1502k      0 --:--:--  0:00:04 --:--:-- 2088k
module.lambda-test.null_resource.download_package (local-exec): 100 8162k    0 8162k    0     0  1465k      0 --:--:--  0:00:05 --:--:-- 1907k
module.lambda-test.null_resource.download_package (local-exec): 100 9009k    0 9009k    0     0  1372k      0 --:--:--  0:00:06 --:--:-- 1679k
module.lambda-test.null_resource.download_package (local-exec): 100 9785k    0 9785k    0     0  1293k      0 --:--:--  0:00:07 --:--:-- 1219k
module.lambda-test.null_resource.download_package (local-exec): 100 10.4M    0 10.4M    0     0  1244k      0 --:--:--  0:00:08 --:--:-- 1068k
module.lambda-test.null_resource.download_package (local-exec): 100 11.0M    0 11.0M    0     0  1186k      0 --:--:--  0:00:09 --:--:--  894k
module.lambda-test.null_resource.download_package: Still creating... [10s elapsed]
module.lambda-test.null_resource.download_package (local-exec): 100 11.5M    0 11.5M    0     0  1122k      0 --:--:--  0:00:10 --:--:--  741k
module.lambda-test.null_resource.download_package (local-exec): 100 12.1M    0 12.1M    0     0  1078k      0 --:--:--  0:00:11 --:--:--  691k
module.lambda-test.null_resource.download_package (local-exec): 100 12.7M    0 12.7M    0     0  1035k      0 --:--:--  0:00:12 --:--:--  644k
module.lambda-test.null_resource.download_package (local-exec): 100 13.3M    0 13.3M    0     0  1004k      0 --:--:--  0:00:13 --:--:--  592k
module.lambda-test.null_resource.download_package (local-exec): 100 14.2M    0 14.2M    0     0  1001k      0 --:--:--  0:00:14 --:--:--  646k
module.lambda-test.null_resource.download_package (local-exec): 100 14.3M    0 14.3M    0     0  1002k      0 --:--:--  0:00:14 --:--:--  693k
module.lambda-test.null_resource.download_package (local-exec): Archive:  downloaded_package_65d64672524938bc7a14a0858494b3d0.zip
module.lambda-test.null_resource.download_package (local-exec): e340db5e971e7f3f7d3c5bf97d816ececc68c27a
module.lambda-test.null_resource.download_package (local-exec):    creating: .terraform/modules/lambda-test/terraform-aws-logs-to-opensearch-1.0.0/
module.lambda-test.null_resource.download_package (local-exec):   inflating: .terraform/modules/lambda-test/terraform-aws-logs-to-opensearch-1.0.0/LICENSE.md
module.lambda-test.null_resource.download_package (local-exec):   inflating: .terraform/modules/lambda-test/terraform-aws-logs-to-opensearch-1.0.0/README.md
module.lambda-test.null_resource.download_package (local-exec):   inflating: .terraform/modules/lambda-test/terraform-aws-logs-to-opensearch-1.0.0/alb-logs-to-elasticsearch.zip

module.lambda-test.null_resource.download_package (local-exec):    creating: .terraform/modules/lambda-test/terraform-aws-logs-to-opensearch-1.0.0/files/
module.lambda-test.null_resource.download_package (local-exec):   inflating: .terraform/modules/lambda-test/terraform-aws-logs-to-opensearch-1.0.0/files/es_policy.json
module.lambda-test.null_resource.download_package (local-exec):   inflating: .terraform/modules/lambda-test/terraform-aws-logs-to-opensearch-1.0.0/iam.tf
module.lambda-test.null_resource.download_package (local-exec):   inflating: .terraform/modules/lambda-test/terraform-aws-logs-to-opensearch-1.0.0/lambda.tf
module.lambda-test.null_resource.download_package (local-exec):   inflating: .terraform/modules/lambda-test/terraform-aws-logs-to-opensearch-1.0.0/locals.tf
module.lambda-test.null_resource.download_package (local-exec):   inflating: .terraform/modules/lambda-test/terraform-aws-logs-to-opensearch-1.0.0/s3.tf
module.lambda-test.null_resource.download_package (local-exec):   inflating: .terraform/modules/lambda-test/terraform-aws-logs-to-opensearch-1.0.0/sg.tf
module.lambda-test.null_resource.download_package (local-exec):   inflating: .terraform/modules/lambda-test/terraform-aws-logs-to-opensearch-1.0.0/variables.tf
module.lambda-test.null_resource.download_package (local-exec):  extracting: .terraform/modules/lambda-test/terraform-aws-logs-to-opensearch-1.0.0/versions.tf
module.lambda-test.null_resource.download_package: Creation complete after 14s [id=4265707704064949397]

```

